### PR TITLE
chore: move dotfiles config to ~/code/dotfiles

### DIFF
--- a/modules/core/nix.nix
+++ b/modules/core/nix.nix
@@ -39,6 +39,7 @@
     settings = {
       experimental-features = "nix-command flakes";
       flake-registry = ./registry.json;
+      accept-flake-config = true;
 
       trusted-users = [
         "root"

--- a/modules/user/shell/zsh.nix
+++ b/modules/user/shell/zsh.nix
@@ -1,6 +1,6 @@
 { config, pkgs, ... }:
 let
-  configDirectory = "${config.home.homeDirectory}/.config/nix";
+  configDirectory = "${config.home.homeDirectory}/code/dotfiles";
 in
 {
   home.packages = [ pkgs.any-nix-shell ];

--- a/nix.conf
+++ b/nix.conf
@@ -1,1 +1,0 @@
-experimental-features = nix-command flakes


### PR DESCRIPTION
## Summary

- Add `accept-flake-config = true` to `nix.settings` in nix-darwin (`modules/core/nix.nix`)
- Remove manual `nix.conf` from repo root — settings now fully managed by nix-darwin
- Update `configDirectory` in zsh aliases to point to `~/code/dotfiles`

## After merging

Run these steps in order:

```bash
# 1. Apply the new config (still works via existing symlink ~/code/dotfiles → ~/.config/nix)
just switch

# 2. Remove the old symlink
rm ~/code/dotfiles

# 3. Move the actual repo
mv ~/.config/nix ~/code/dotfiles

# 4. Reload the shell
source ~/.zshrc
```

Note: `~/.config/nix` is NOT recreated as a symlink — Nix writes its config to `/etc/nix/nix.conf` via nix-darwin.