### PR TITLE
docs(user/apps/coding-agents): split hard-wrap rule into prose vs structural

### DIFF
--- a/modules/user/apps/coding-agents/AGENTS.md
+++ b/modules/user/apps/coding-agents/AGENTS.md
@@ -9,7 +9,9 @@ Hard rules are absolute — violating one is a failure, not a judgment call. Eve
 - Never run a destructive or irreversible command (`rm`, `git reset --hard`, force-push, dropping data) without that same explicit, this-turn approval.
 - Approval is per-action and per-turn — it never carries forward, and silence, an emoji, or an earlier "looks good" is not consent. When in doubt, ask before acting.
 - Never sign your output — no footer, signature, or `Co-authored-by`, anywhere (commits, PRs, comments).
-- Never hard-wrap prose you generate (80 cols or any width) unless I ask. Soft-wrap everything.
+- Never hard-wrap prose you generate — no column width, ever, unless I ask:
+  - Prose (one raw line per paragraph, no matter the length; let the renderer wrap it): commit message bodies, PR/issue descriptions, doc paragraphs, multi-sentence code comments, chat responses.
+  - Not prose — line breaks are structural and always fine: markdown headers, list items (one item = one line), table rows, code/YAML/JSON blocks, blockquote lines.
 - Never `brew install` or `apt` — ephemeral tools go through `nix shell nixpkgs#<tool>`.
 - Never hand-edit dotfiles under `$HOME/` when a home-manager module can do it.
 - Never claim something works without having watched it pass this session.

--- a/modules/user/apps/coding-agents/check-hardwrap.sh
+++ b/modules/user/apps/coding-agents/check-hardwrap.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Flags prose paragraphs split across multiple raw lines. See AGENTS.md:
+# "Never hard-wrap prose you generate ... Soft-wrap everything." Headers,
+# list items, table rows, blockquotes, and code blocks are structural and
+# may keep their own line breaks.
+#
+# Usage: check-hardwrap.sh <file>
+set -euo pipefail
+
+file="$1"
+violations=0
+block=()
+has_fence=0
+in_fence=0
+
+is_structural_line() {
+	local line="$1"
+	[[ "$line" =~ ^#+[[:space:]] ]] && return 0
+	[[ "$line" =~ ^[-*][[:space:]] ]] && return 0
+	[[ "$line" =~ ^[0-9]+\.[[:space:]] ]] && return 0
+	[[ "$line" =~ ^\| ]] && return 0
+	[[ "$line" =~ ^\> ]] && return 0
+	return 1
+}
+
+flush_block() {
+	if [[ ${#block[@]} -gt 1 && "$has_fence" -eq 0 ]]; then
+		local structural=1
+		for line in "${block[@]}"; do
+			is_structural_line "$line" || { structural=0; break; }
+		done
+		if [[ "$structural" -eq 0 ]]; then
+			violations=$((violations + 1))
+			printf 'hard-wrapped prose paragraph:\n' >&2
+			printf '  %s\n' "${block[@]}" >&2
+		fi
+	fi
+	block=()
+	has_fence=0
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+	if [[ "$line" =~ ^'```' ]]; then
+		in_fence=$((1 - in_fence))
+		has_fence=1
+		block+=("$line")
+		continue
+	fi
+	if [[ "$in_fence" -eq 1 ]]; then
+		block+=("$line")
+		continue
+	fi
+	if [[ -z "$line" ]]; then
+		flush_block
+	else
+		block+=("$line")
+	fi
+done < "$file"
+flush_block
+
+exit "$((violations > 0 ? 1 : 0))"

--- a/modules/user/apps/coding-agents/check-hardwrap.test.sh
+++ b/modules/user/apps/coding-agents/check-hardwrap.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# TDD fixtures for check-hardwrap.sh, per issue #83: a prose paragraph must be
+# one raw line, while structural markdown (headers, lists, tables, code
+# blocks, blockquotes) may keep its own line breaks.
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+checker="$dir/check-hardwrap.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+
+# Case 1: a prose paragraph hard-wrapped at ~80 cols (the PR-body scenario
+# described in the issue) must be flagged as a violation.
+cat > "$tmp/hardwrapped.md" <<'EOF'
+## Problem
+
+Writing a PR description, paragraphs got wrapped at the traditional 80-col
+commit-body width. Headers, bullet list items, and table rows were correctly
+left alone, but the paragraphs above them got the same column-wrap treatment
+prose should never get.
+
+- one
+- two
+EOF
+
+if "$checker" "$tmp/hardwrapped.md" >/dev/null 2>&1; then
+	echo "FAIL: expected hardwrapped.md to be flagged as a violation"
+	fail=1
+else
+	echo "PASS: hardwrapped.md correctly flagged"
+fi
+
+# Case 2: the same prose as a single raw line, with structural elements
+# (header, list) kept multi-line, must pass untouched.
+cat > "$tmp/softwrapped.md" <<'EOF'
+## Problem
+
+Writing a PR description, paragraphs got wrapped at the traditional 80-col commit-body width. Headers, bullet list items, and table rows were correctly left alone, but the paragraphs above them got the same column-wrap treatment prose should never get.
+
+- one
+- two
+EOF
+
+if "$checker" "$tmp/softwrapped.md" >/dev/null 2>&1; then
+	echo "PASS: softwrapped.md correctly accepted"
+else
+	echo "FAIL: expected softwrapped.md to pass"
+	fail=1
+fi
+
+exit "$fail"


### PR DESCRIPTION
## Summary

Closes #83. The "never hard-wrap prose" rule got misread while writing a real PR body: free paragraphs were manually broken at ~80 cols, exactly what the rule forbids. This expands the rule with an explicit prose-vs-structural split (headers, list items, table rows, code blocks, and blockquotes may keep their own line breaks; everything else — commit bodies, PR/issue descriptions, doc paragraphs, chat responses — is one raw line per paragraph).

Also adds `check-hardwrap.sh`, a small executable version of the rule, plus two fixture-based tests reproducing the exact scenario from the issue.

## TDD evidence (before/after)

Before implementing the checker (only the test file existed):

```
PASS: hardwrapped.md correctly flagged
FAIL: expected softwrapped.md to pass
exit=1
```

After implementing `check-hardwrap.sh`:

```
PASS: hardwrapped.md correctly flagged
PASS: softwrapped.md correctly accepted
exit=0
```

## Test plan

- [x] `bash modules/user/apps/coding-agents/check-hardwrap.test.sh` — both fixtures pass
- [x] `shellcheck` on both new scripts — clean