### PR TITLE
feat(sops): bring up sops-nix, read fj fallback forge host from encrypted secret

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,8 @@
+keys:
+  - &emaiax age1yhmyckwlsp00w53ttfelgptw2u4ms5rn3x0zd94fmvu94t24usvqkk0zxv
+
+creation_rules:
+  - path_regex: secrets/.*\.enc\.yaml$
+    key_groups:
+      - age:
+          - *emaiax

--- a/flake.lock
+++ b/flake.lock
@@ -132,7 +132,28 @@
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nix-vscode-extensions": "nix-vscode-extensions",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "sops-nix": "sops-nix"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,11 @@
 
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
     nix-vscode-extensions.url = "github:nix-community/nix-vscode-extensions";
+
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -26,6 +31,7 @@
       nix-homebrew,
       nixpkgs,
       nix-vscode-extensions,
+      ...
     }:
     let
       inventory = import ./nix/inventory.nix;

--- a/modules/user/default.nix
+++ b/modules/user/default.nix
@@ -5,6 +5,7 @@
     ./shell
     ./git
     ./packages
+    ./sops
   ];
 
   # ensures ~/code folder exists

--- a/modules/user/git/default.nix
+++ b/modules/user/git/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 {
   imports = [
     ./git.nix
@@ -6,4 +6,14 @@
   ];
 
   home.packages = [ pkgs.forgejo-cli ];
+
+  # fj resolves its instance from the cwd's git remote; this is the
+  # fallback everywhere else. The URL is private, so it comes from a
+  # sops secret read at shell startup instead of a nix-store literal.
+  sops.secrets.fj-fallback-host = { };
+
+  programs.zsh.initContent = ''
+    [[ -r "${config.sops.secrets.fj-fallback-host.path}" ]] &&
+      export FJ_FALLBACK_HOST="$(<"${config.sops.secrets.fj-fallback-host.path}")"
+  '';
 }

--- a/modules/user/sops/default.nix
+++ b/modules/user/sops/default.nix
@@ -1,0 +1,9 @@
+{ config, inputs, ... }:
+{
+  imports = [ inputs.sops-nix.homeManagerModules.sops ];
+
+  sops = {
+    defaultSopsFile = ../../../secrets/secrets.enc.yaml;
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+  };
+}

--- a/secrets/secrets.enc.yaml
+++ b/secrets/secrets.enc.yaml
@@ -1,0 +1,16 @@
+fj-fallback-host: ENC[AES256_GCM,data:k2269Jn9gzBp+iHB9VEXQo9fefFg3Z6g,iv:8YkkrR+RykZpar0ZuzcJ2WsRlht69V8uKmGeUPQ/fz8=,tag:NvWrAZ6OFudQRfKnBMGOzA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxME4vc3U2R0tkRlYveE1O
+            NU1pRi91bGhQdkdNUTRDWm1xMnBOWXIxSURnCnJ3WmFOamFGdDdXNEs3QlR5LzMr
+            Zk8xM3g1UHNGdHo1NjNGUW0yQUdCcTgKLS0tIFg5TXBTVTJtdFFHMnBnWlU3bEhy
+            b1V5eDJNUi9QUWQ2NUFkQ2ttcDBpTlEKJ6aoiohiNog7z+A87j2fXbNd1h9sfN14
+            H5NqLwKmQaIvaa+sFlut14djQG1FrfT93uqT8QzGoii2m/uGu35Kag==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1yhmyckwlsp00w53ttfelgptw2u4ms5rn3x0zd94fmvu94t24usvqkk0zxv
+    lastmodified: "2026-07-11T06:07:23Z"
+    mac: ENC[AES256_GCM,data:9XL8BpZ6tPRbsX1bT37w1S+5uvMtWTdUG5yrL0RJ7UExsI7WrjfewuzFVeaAgdTB4biL3yAqwo8M6BAB5JzHFTYG8f7ZxAaQAkQ7Opp7Y5jWzNfYhxaZK/kI6XgNSjgRZ7KGfqpvBtK5RFx3+kouF0g1mHvUKMaAtvJ1QuyTFNU=,iv:oHINJU4jRLEXvUoqevmiemp913eSrqDiqWUZW5EwL+A=,tag:123m5Mvc9IISGJhsYZRCVw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1


### PR DESCRIPTION
## What

Brings SOPS-encrypted secrets to the dotfiles via [sops-nix](https://github.com/Mic92/sops-nix)'s home-manager module, and uses it for the first secret: the `fj` (forgejo-cli) fallback forge host.

## Why

`fj` resolves its target instance from the cwd's git remote and, failing that, from the `FJ_FALLBACK_HOST` env var ([resolution order](https://codeberg.org/forgejo-contrib/forgejo-cli/src/tag/v0.5.0/src/repo.rs), confirmed by the maintainer in [forgejo-cli#444](https://codeberg.org/forgejo-contrib/forgejo-cli/issues/444)). Without the fallback, every command outside a repo with a forge remote needs `-H <host>`.

The forge host URL is private, so it can't be a plaintext literal in nix code (anything in `home.sessionVariables` lands world-readable in the nix store). It now lives only inside a SOPS-encrypted file.

## How

- `flake.nix`: `sops-nix` input (`nixpkgs` follows); `...` added to the outputs destructure
- `.sops.yaml`: personal age recipient (public key only)
- `secrets/secrets.enc.yaml`: encrypted payload holding `fj-fallback-host`
- `modules/user/sops/`: generic bring-up — imports the sops-nix HM module, points `age.keyFile` at the local age key; secrets decrypt once per login via launchd agent to a user-owned 0400 file
- `modules/user/git/`: declares the secret next to `pkgs.forgejo-cli` and exports `FJ_FALLBACK_HOST` in zsh init by reading the decrypted file at runtime

## Verified

- `darwin-rebuild build` passes
- After `switch`: launchd agent `org.nix-community.home.sops-nix` exits 0, secret decrypted with mode 0400
- Fresh interactive zsh outside any git repo: `fj whoami` succeeds with no `-H`

Note: the export runs in `.zshrc`, so non-interactive shells don't get the var — acceptable for interactive CLI use; move to `.zshenv` later if scripts ever need it.