### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783689750,
-        "narHash": "sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb+A9ehn8k=",
+        "lastModified": 1783817100,
+        "narHash": "sha256-rUILR3Ce6S2mMvGNFkd2G5uD4s6X+R4HA91etOq8FAU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79e6082586b3680ff32c8e75127545058f074fa4",
+        "rev": "c74f4f6cdd3afbfda55995a4a97333ed5cf13f45",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783655619,
-        "narHash": "sha256-KwlfSN9Py11iYlG56AsjmhJfCtfzPlS2YgyHJ1cIZ80=",
+        "lastModified": 1783739870,
+        "narHash": "sha256-AlZ6alGgglSnobDd0TJCWTu822os+2PxEGy7nZyI33E=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "6cb9c541989996f3481ce747865c9dbe37be719e",
+        "rev": "a187e07424aa1d5e4ec148408d8e2873501d7bb8",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783475452,
-        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
+        "lastModified": 1783791668,
+        "narHash": "sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
+        "rev": "716c7a2664ca8325617b8a7fbb609273f2c4cae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `nix flake update`.

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/79e6082586b3680ff32c8e75127545058f074fa4?narHash=sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb%2BA9ehn8k%3D' (2026-07-10)
  → 'github:nix-community/home-manager/c74f4f6cdd3afbfda55995a4a97333ed5cf13f45?narHash=sha256-rUILR3Ce6S2mMvGNFkd2G5uD4s6X%2BR4HA91etOq8FAU%3D' (2026-07-12)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/6cb9c541989996f3481ce747865c9dbe37be719e?narHash=sha256-KwlfSN9Py11iYlG56AsjmhJfCtfzPlS2YgyHJ1cIZ80%3D' (2026-07-10)
  → 'github:nix-community/nix-vscode-extensions/a187e07424aa1d5e4ec148408d8e2873501d7bb8?narHash=sha256-AlZ6alGgglSnobDd0TJCWTu822os%2B2PxEGy7nZyI33E%3D' (2026-07-11)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/05988b07fb05cbcb50be6bce197b4b5f75b5e61b?narHash=sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco%3D' (2026-07-08)
  → 'github:NixOS/nixpkgs/716c7a2664ca8325617b8a7fbb609273f2c4cae7?narHash=sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA%3D' (2026-07-11)
```