### PR TITLE
docs(user/apps/coding-agents): cover indirectly generated prose in hard-wrap rule

### DIFF
--- a/modules/user/apps/coding-agents/AGENTS.md
+++ b/modules/user/apps/coding-agents/AGENTS.md
@@ -12,6 +12,7 @@ Hard rules are absolute — violating one is a failure, not a judgment call. Eve
 - Never hard-wrap prose you generate — no column width, ever, unless I ask:
   - Prose (one raw line per paragraph, no matter the length; let the renderer wrap it): commit message bodies, PR/issue descriptions, doc paragraphs, multi-sentence code comments, chat responses.
   - Not prose — line breaks are structural and always fine: markdown headers, list items (one item = one line), table rows, code/YAML/JSON blocks, blockquote lines.
+  - This applies even when the prose is generated indirectly — inside a script, heredoc, template, or CI workflow that assembles a commit/PR/doc body at runtime. Judge by the rendered artifact the prose ends up in, not by how the generating source looks in an editor.
 - Never `brew install` or `apt` — ephemeral tools go through `nix shell nixpkgs#<tool>`.
 - Never hand-edit dotfiles under `$HOME/` when a home-manager module can do it.
 - Never claim something works without having watched it pass this session.


### PR DESCRIPTION
## Summary

Closes #85. The hard-wrap rule in AGENTS.md already split prose from structural line breaks (#83), but it only listed prose typed directly (commit bodies, PR/issue descriptions, doc paragraphs, comments, chat responses). It didn't say whether the rule covers prose assembled indirectly by generated code — e.g. a heredoc inside a CI workflow that writes a PR body at runtime — and in practice that gap led to hard-wrapped prose shipping in a real nixpkgs PR.

## Changes

Added a clause stating the rule applies even when prose is generated indirectly (script, heredoc, template, CI workflow), and that it should be judged by the rendered artifact, not by how the generating source looks in an editor.

Per the issue's note, not reviving the `check-hardwrap.sh` demonstration checker dropped in 764f0a9 — this is a documentation-only fix.

## Test plan

- [x] Reviewed the diff for hard-wrap compliance in the new prose line itself