### PR TITLE
fix(nix): pin dudumini to nixpkgs-26.05-darwin, keep dudupro on unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,6 +110,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-darwin-stable": {
+      "locked": {
+        "lastModified": 1783788001,
+        "narHash": "sha256-ldd//kQFtHfGWLQd6deNXB6GnN6uLmwjPG6GGx/2vTA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "572a2c2b6faebd71246e3162e4217d7ca63a9300",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1783475452,
@@ -133,6 +149,7 @@
         "nix-homebrew": "nix-homebrew",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-darwin-stable": "nixpkgs-darwin-stable",
         "sops-nix": "sops-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
+    # nixpkgs-unstable dropped x86_64-darwin support (26.11); dudumini (Intel)
+    # pins to the last stable branch that still builds it, via nixpkgs.source.
+    nixpkgs-darwin-stable.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/hosts/dudumini.nix
+++ b/nix/hosts/dudumini.nix
@@ -1,5 +1,9 @@
-{ ... }:
+{ inputs, ... }:
 {
+  # nixpkgs-unstable dropped x86_64-darwin support (26.11); pin this host to
+  # the last stable branch that still supports it (26.05, EOL end of 2026).
+  nixpkgs.source = inputs.nixpkgs-darwin-stable;
+
   imports = [
     ../../modules/system/darwin/networking.nix
     ../../modules/system/darwin/security/pam-watch-id.nix


### PR DESCRIPTION
## Summary
- `nixpkgs-unstable` dropped x86_64-darwin support in the 26.11 cycle, which broke `dudumini` (Intel) CI builds in #87.
- The same nixpkgs bump also surfaced a real linker regression building `watchexec-2.5.1` on aarch64-darwin (`dudupro`) — reproduced locally, not CI flakiness.
- Adds a `nixpkgs-darwin-stable` input tracking `nixpkgs-26.05-darwin` (security fixes until end of 2026) and pins `dudumini` to it via nix-darwin's `nixpkgs.source` option. `dudupro` keeps following `nixpkgs-unstable` unchanged.

## Test plan
- [x] `dudupro` (Apple Silicon, matches local hardware): full local `darwin-rebuild build --flake .#dudupro` succeeded.
- [x] `watchexec-2.5.1` builds successfully on `nixpkgs-26.05-darwin` locally (the linker crash from #87 does not reproduce there).
- [ ] `dudumini` (Intel): could not be natively build/tested locally (no Intel hardware available) — needs CI on the `macos-15-intel` runner to confirm. A local cross-arch (aarch64→x86_64) eval hit an unrelated pre-existing self-reference in `modules/core/nixpkgs.nix` (`permittedInsecurePackages` referencing `pkgs.arc-browser`) that only manifests under cross-compilation bootstrap, not native eval — out of scope for this fix.

Closes the broken-CI PR #87 (closed without merging; its dependency bump was reverted here in favor of this per-host pin).