### PR TITLE
ci(build): drop dudumini (x86_64-darwin) from the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # x86_64-darwin must build on a native Intel runner
-          - host: dudumini
-            runner: macos-15-intel
+          # dudumini (x86_64-darwin) dropped from CI: nixpkgs-unstable no
+          # longer supports the architecture as of the 26.11 cycle.
           - host: dudupro
             runner: macos-15
 


### PR DESCRIPTION
## Summary
- nixpkgs-unstable dropped x86_64-darwin support in the 26.11 cycle (see PR #87), breaking every dudumini CI build.
- Per-host nixpkgs pinning was explored in PR #89 (closed): nix-darwin's own internal branch-match checks (documentation module, darwin-uninstaller package) each make their own nested eval-config.nix call that ignores per-host overrides, comparing against that host's actual pkgs.lib. Making dudumini track an older stable nixpkgs while nix-darwin/home-manager/sops-nix stay on unstable is unworkable without a second, matching nix-darwin input.
- Decommissioning dudumini from CI for now. `nix/hosts/dudumini.nix` and its inventory entry are left in place; only the build matrix job is removed.

## Test plan
- [x] `nix flake check` unaffected (lint job only touches formatting/flake metadata, not the build matrix).
- [x] Reviewed workflow diff: only removes the `dudumini`/`macos-15-intel` matrix entry, `dudupro` job untouched.