### PR TITLE
fix(nix-daemon): fix linux-builder feature scheduling for nixosTest

### DIFF
--- a/modules/core/nix-daemon.nix
+++ b/modules/core/nix-daemon.nix
@@ -20,8 +20,13 @@
         "aarch64-linux"
       ];
 
+      # kvm is intentionally not listed: the VM boots via QEMU+HVF
+      # (accel=hvf:tcg) and does not expose /dev/kvm to the guest, so
+      # nested-virtualization builds (nixosTest) cannot actually run here.
+      # Declaring kvm anyway lets Nix schedule such builds onto this
+      # machine, where they fail with a garbled exec error instead of a
+      # clean "missing system features" rejection. See dotfiles#82.
       supportedFeatures = [
-        "kvm"
         "benchmark"
         "big-parallel"
       ];

--- a/modules/core/nix-daemon.nix
+++ b/modules/core/nix-daemon.nix
@@ -22,16 +22,43 @@
 
       # kvm is intentionally not listed: the VM boots via QEMU+HVF
       # (accel=hvf:tcg) and does not expose /dev/kvm to the guest, so
-      # nested-virtualization builds (nixosTest) cannot actually run here.
-      # Declaring kvm anyway lets Nix schedule such builds onto this
-      # machine, where they fail with a garbled exec error instead of a
-      # clean "missing system features" rejection. See dotfiles#82.
+      # nested-virtualization builds (nixosTest with a VM backend) cannot
+      # actually run here. Declaring kvm anyway lets Nix schedule such
+      # builds onto this machine, where they fail with a garbled exec
+      # error instead of a clean "missing system features" rejection.
+      # See dotfiles#82.
+      #
+      # nixos-test and uid-range are listed so container-backed nixosTest
+      # derivations (systemd-nspawn, e.g. most prometheus exporter tests)
+      # can schedule here. uid-range requires auto-allocate-uids below —
+      # without it the build sandbox keeps the real single build uid
+      # (no root inside the container), and systemd-nspawn refuses to run.
       supportedFeatures = [
         "benchmark"
         "big-parallel"
+        "nixos-test"
+        "uid-range"
       ];
 
       config = {
+        nix.settings = {
+          # cgroups is required alongside auto-allocate-uids/uid-range for
+          # container-backed nixosTest derivations (systemd-nspawn) to
+          # actually spawn on this builder.
+          extra-experimental-features = [
+            "auto-allocate-uids"
+            "cgroups"
+          ];
+          auto-allocate-uids = true;
+
+          # NixOS's own `nix.settings.system-features` default
+          # (nixos/modules/config/nix.nix) is a static list that predates
+          # auto-allocate-uids and does not add "uid-range" for it, unlike
+          # plain Nix's dynamic default. `extra-system-features` appends to
+          # that static list instead of replacing it.
+          extra-system-features = [ "uid-range" ];
+        };
+
         virtualisation = {
           cores = 4;
 


### PR DESCRIPTION
## Summary

- Removes `kvm` from `nix.linux-builder.config.supportedFeatures`. The linux-builder VM boots via QEMU+HVF (`accel=hvf:tcg`), which never exposes `/dev/kvm` to the guest — nested-virtualization builds (`nixosTest` with a VM backend) cannot run inside it, no matter what the config claims.
- Declaring `kvm` as supported let Nix schedule such derivations onto this machine anyway, where they'd crash with a garbled `Undefined error: 0` exec failure instead of a clean scheduling rejection.
- Follow-up (same root problem, wider fix): most `prometheus-exporters` nixosTests (and others) use the container backend (`systemd-nspawn`), not a VM, and don't need KVM at all. They were still being rejected at scheduling because this builder didn't advertise `nixos-test`/`uid-range`, and even once scheduled, `systemd-nspawn` needs a real root-mapped UID range inside the sandbox to start. Added `nixos-test`/`uid-range` to `supportedFeatures`, plus `auto-allocate-uids` and the `cgroups`/`auto-allocate-uids` experimental Nix features on the guest, so container-backed nixosTest derivations can actually run here. NixOS's own default for `nix.settings.system-features` is a static list that predates `auto-allocate-uids` and doesn't add `uid-range` for it automatically (unlike plain Nix's dynamic default), hence the explicit `extra-system-features`.

## Verification

- `/dev/kvm` is absent inside the guest (`ls: cannot access '/dev/kvm': No such file or directory`), confirmed via a real dispatched build.
- Before the fix, `nixosTests.login` and `nixosTests.prometheus-exporters.speedtest-ookla` were already rejected at scheduling time (`missing system features`), just for the wrong/incomplete reason (`nixos-test` also missing from `supportedFeatures`).
- After `darwin-rebuild switch`, `/etc/nix/machines` no longer advertises `kvm` for the builder, and now advertises `nixos-test`/`uid-range`.
- Re-tested `nixosTests.prometheus-exporters.speedtest-ookla` end to end (via `overrideTestDerivation` to drop the still-required `kvm` from that one test, since it's a VM-backend leftover default unrelated to this test's container backend): it schedules, boots the container, the exporter starts, and `curl -sSf http://localhost:9876` succeeds inside the test.
- Re-tested `nixosTest` scenarios post-fix: VM-backed `nixosTest` builds are still cleanly rejected (now for the honest reason, missing `kvm`), and plain `aarch64-linux` builds still dispatch and complete normally on the builder.
- Confirmed the guest kernel itself supports unprivileged user namespaces fine (`unshare -Ur id` → uid 0) — the earlier `uid-range` rejection was pure Nix/NixOS configuration, not a kernel limitation.

## Test plan

- [x] `just build` evaluates cleanly
- [x] `just switch` applied without errors
- [x] `/etc/nix/machines` reflects the change post-switch
- [x] `nixosTests.login` still rejected cleanly at scheduling time
- [x] plain `aarch64-linux` build dispatches and completes on the builder
- [x] `nixosTests.prometheus-exporters.speedtest-ookla` (container-backed) schedules and passes on the builder
