### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           # dudumini (x86_64-darwin) dropped from CI: nixpkgs-unstable no
           # longer supports the architecture as of the 26.11 cycle.
           - host: dudupro
+            system: aarch64-darwin
             runner: macos-15
 
     runs-on: ${{ matrix.runner }}
@@ -43,4 +44,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
 
-      - run: nix build .#darwinConfigurations.${{ matrix.host }}.system
+      # Builds flake.nix's checks.<system>.build-<host> instead of
+      # darwinConfigurations.<host>.system directly: that check mirrors the
+      # real host but with nix.linux-builder disabled, since this runner has
+      # no way to build its aarch64-linux VM image and no guarantee
+      # cache.nixos.org already has it substituted for the pinned nixpkgs rev.
+      - run: nix build .#checks.${{ matrix.system }}.build-${{ matrix.host }}

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1781226006,
-        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
+        "lastModified": 1784068757,
+        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
+        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.1",
+        "ref": "6.0.11",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783689750,
-        "narHash": "sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb+A9ehn8k=",
+        "lastModified": 1784407317,
+        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79e6082586b3680ff32c8e75127545058f074fa4",
+        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783395956,
-        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "lastModified": 1784362797,
+        "narHash": "sha256-EP9b9b+OXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "rev": "b4cccbd4bc299c1f71ae185b79c3cf99aa82805c",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1781389246,
-        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
+        "lastModified": 1784159664,
+        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
+        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783655619,
-        "narHash": "sha256-KwlfSN9Py11iYlG56AsjmhJfCtfzPlS2YgyHJ1cIZ80=",
+        "lastModified": 1784343266,
+        "narHash": "sha256-EGkegdTz2n6ESyih8s3dUuPyJQWlYfPp7U41J05g8PY=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "6cb9c541989996f3481ce747865c9dbe37be719e",
+        "rev": "472a3e862c76c64ac3ad75a24d332cb5cdd5f1bb",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783475452,
-        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784364478,
-        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
+        "lastModified": 1783475452,
+        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
+        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,9 @@
 
       mkDarwinHost =
         host:
+        {
+          extraModules ? [ ],
+        }:
         nix-darwin.lib.darwinSystem {
           system = host.arch; # uses host's arch (aarch64/x86_64)
 
@@ -92,11 +95,24 @@
             #
             ./nix/hosts/${host.hostname}.nix # host-specific overrides
             ./nix/profiles/${host.user.username}.nix # user-specific overrides
-          ];
+          ]
+          ++ extraModules;
         };
     in
     {
-      darwinConfigurations = builtins.mapAttrs (name: host: mkDarwinHost host) inventory.hosts;
+      darwinConfigurations = builtins.mapAttrs (name: host: mkDarwinHost host { }) inventory.hosts;
+
+      # CI builds the full darwin system closure on an ephemeral macOS runner,
+      # which cannot build nix.linux-builder's aarch64-linux VM image itself
+      # (no way to run Linux binaries on macOS, no remote builder registered)
+      # and has no guarantee that cache.nixos.org already has that VM
+      # substituted for whatever nixpkgs revision the flake currently pins.
+      # This mirrors dudupro with linux-builder disabled so CI still catches
+      # real eval/build regressions without depending on that cache.
+      checks.aarch64-darwin.build-dudupro =
+        (mkDarwinHost inventory.hosts.dudupro {
+          extraModules = [ { nix.linux-builder.enable = nixpkgs.lib.mkForce false; } ];
+        }).config.system.build.toplevel;
 
       formatter = nixpkgs.lib.genAttrs [
         "x86_64-darwin"


### PR DESCRIPTION
Automated `nix flake update`.

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/79e6082586b3680ff32c8e75127545058f074fa4?narHash=sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb%2BA9ehn8k%3D' (2026-07-10)
  → 'github:nix-community/home-manager/39411a8e12a5526d992e65bc7e3dc9a4414d6713?narHash=sha256-iZrxHToDJWnvt%2B5LGAtvuQMTy1NZYlNEKbKaVtBJNcc%3D' (2026-07-18)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/d5bd9cd77aea4c0a8f49e7fd85545671a208ed15?narHash=sha256-AAbexQvDoK%2B6GFJdhY6kqjA%2B6ECKRkidgWxkn4gMwAA%3D' (2026-07-07)
  → 'github:LnL7/nix-darwin/b4cccbd4bc299c1f71ae185b79c3cf99aa82805c?narHash=sha256-EP9b9b%2BOXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ%3D' (2026-07-18)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d?narHash=sha256-ORqLAo/hoJdsZC7UPAuEHev6S0%2BXIqKEC7vjo5prz1k%3D' (2026-06-13)
  → 'github:zhaofengli/nix-homebrew/842eeb863ecca0eeb463f7a814cdc51e1d925776?narHash=sha256-I/B6YoRLImHEqNWh8bs%2BtPjEDeteACeFhcLyoSMo1GE%3D' (2026-07-15)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/109191be4988470b51a60a5ef1998520aa24c01b?narHash=sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y%3D' (2026-06-12)
  → 'github:Homebrew/brew/6bd951d96e7ebc54787799dba77bfb26ec956c4c?narHash=sha256-7KnV7rTlMpys%2B2J%2BTFVxUDDyKPLXFs4wIMtckMC72VM%3D' (2026-07-14)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/6cb9c541989996f3481ce747865c9dbe37be719e?narHash=sha256-KwlfSN9Py11iYlG56AsjmhJfCtfzPlS2YgyHJ1cIZ80%3D' (2026-07-10)
  → 'github:nix-community/nix-vscode-extensions/472a3e862c76c64ac3ad75a24d332cb5cdd5f1bb?narHash=sha256-EGkegdTz2n6ESyih8s3dUuPyJQWlYfPp7U41J05g8PY%3D' (2026-07-18)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/05988b07fb05cbcb50be6bce197b4b5f75b5e61b?narHash=sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco%3D' (2026-07-08)
  → 'github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957?narHash=sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY%3D' (2026-07-18)
```