### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784068757,
-        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
+        "lastModified": 1784558651,
+        "narHash": "sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
+        "rev": "b48c7994b5f0eed7bef532efa63cb4e4f763887a",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.11",
+        "ref": "6.0.12",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784407317,
-        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784362797,
-        "narHash": "sha256-EP9b9b+OXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "b4cccbd4bc299c1f71ae185b79c3cf99aa82805c",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1784159664,
-        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
+        "lastModified": 1784906761,
+        "narHash": "sha256-2v0H8+Ert+xbm0oliHblXTPPczuKiibBUBvRax59kxg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
+        "rev": "60623ec512406261f553d24033c8a0c53fd0b7f2",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1784343266,
-        "narHash": "sha256-EGkegdTz2n6ESyih8s3dUuPyJQWlYfPp7U41J05g8PY=",
+        "lastModified": 1784949765,
+        "narHash": "sha256-MB+0noLfsYMoMsBkyG5CKYZmSk7dSXendvvjfQFUiPw=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "472a3e862c76c64ac3ad75a24d332cb5cdd5f1bb",
+        "rev": "242a696abba55b45d577b5292e90b597284f5f85",
         "type": "github"
       },
       "original": {
@@ -96,27 +96,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777207419,
-        "narHash": "sha256-V3bmPWAajDiC+1ClDOp55gianW2EyRJSJOyu1RUQibc=",
+        "lastModified": 1784564315,
+        "narHash": "sha256-7OpsHHIZFUBLbeHNQ0oC40DZRQjsmGWodXge+OqgPgk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a7ecea3deccfbdbf22945a89984fcc5a169da8aa",
+        "rev": "0c2094806c9e542f31785ef3569ab9e900e3ce9c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a7ecea3deccfbdbf22945a89984fcc5a169da8aa",
+        "rev": "0c2094806c9e542f31785ef3569ab9e900e3ce9c",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783475452,
-        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
+        "lastModified": 1784872115,
+        "narHash": "sha256-THPEF2po0fsoH8gNtp+Ae0XFDJH3N/ol7xO3v6VMTJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
+        "rev": "335f0738cb2fa9708f3f428e39d2eae975d1338d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `nix flake update`.

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/39411a8e12a5526d992e65bc7e3dc9a4414d6713?narHash=sha256-iZrxHToDJWnvt%2B5LGAtvuQMTy1NZYlNEKbKaVtBJNcc%3D' (2026-07-18)
  → 'github:nix-community/home-manager/079a3b5d1aa6a719920a51316253b7d6dd22738d?narHash=sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs%3D' (2026-07-24)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/b4cccbd4bc299c1f71ae185b79c3cf99aa82805c?narHash=sha256-EP9b9b%2BOXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ%3D' (2026-07-18)
  → 'github:LnL7/nix-darwin/57a3171f94705599a2499248ca5758d5eb47c0e0?narHash=sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo%3D' (2026-07-19)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/842eeb863ecca0eeb463f7a814cdc51e1d925776?narHash=sha256-I/B6YoRLImHEqNWh8bs%2BtPjEDeteACeFhcLyoSMo1GE%3D' (2026-07-15)
  → 'github:zhaofengli/nix-homebrew/60623ec512406261f553d24033c8a0c53fd0b7f2?narHash=sha256-2v0H8%2BErt%2Bxbm0oliHblXTPPczuKiibBUBvRax59kxg%3D' (2026-07-24)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/6bd951d96e7ebc54787799dba77bfb26ec956c4c?narHash=sha256-7KnV7rTlMpys%2B2J%2BTFVxUDDyKPLXFs4wIMtckMC72VM%3D' (2026-07-14)
  → 'github:Homebrew/brew/b48c7994b5f0eed7bef532efa63cb4e4f763887a?narHash=sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI%3D' (2026-07-20)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/472a3e862c76c64ac3ad75a24d332cb5cdd5f1bb?narHash=sha256-EGkegdTz2n6ESyih8s3dUuPyJQWlYfPp7U41J05g8PY%3D' (2026-07-18)
  → 'github:nix-community/nix-vscode-extensions/242a696abba55b45d577b5292e90b597284f5f85?narHash=sha256-MB%2B0noLfsYMoMsBkyG5CKYZmSk7dSXendvvjfQFUiPw%3D' (2026-07-25)
• Updated input 'nix-vscode-extensions/nixpkgs':
    'github:nixos/nixpkgs/a7ecea3deccfbdbf22945a89984fcc5a169da8aa?narHash=sha256-V3bmPWAajDiC%2B1ClDOp55gianW2EyRJSJOyu1RUQibc%3D' (2026-04-26)
  → 'github:nixos/nixpkgs/0c2094806c9e542f31785ef3569ab9e900e3ce9c?narHash=sha256-7OpsHHIZFUBLbeHNQ0oC40DZRQjsmGWodXge%2BOqgPgk%3D' (2026-07-20)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/05988b07fb05cbcb50be6bce197b4b5f75b5e61b?narHash=sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco%3D' (2026-07-08)
  → 'github:NixOS/nixpkgs/335f0738cb2fa9708f3f428e39d2eae975d1338d?narHash=sha256-THPEF2po0fsoH8gNtp%2BAe0XFDJH3N/ol7xO3v6VMTJU%3D' (2026-07-24)
```