### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1785483748,
-        "narHash": "sha256-M4HXpLsR7iFTNQfD/q+zK8/QeRYztYVDVIdIgCVGGZ0=",
+        "lastModified": 1785542685,
+        "narHash": "sha256-sjfvXMbG5pCFgpvw2OZAFcZiTvrppCWvnB6cuGrSY08=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59ea0b1c043c463e39fcb3cfb9a5c8bcf0777c72",
+        "rev": "f8e81fc7eb063db454f563cdd596fb96a5ad1497",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `nix flake update`.

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/59ea0b1c043c463e39fcb3cfb9a5c8bcf0777c72?narHash=sha256-M4HXpLsR7iFTNQfD/q%2BzK8/QeRYztYVDVIdIgCVGGZ0%3D' (2026-07-31)
  → 'github:NixOS/nixpkgs/f8e81fc7eb063db454f563cdd596fb96a5ad1497?narHash=sha256-sjfvXMbG5pCFgpvw2OZAFcZiTvrppCWvnB6cuGrSY08%3D' (2026-08-01)
```